### PR TITLE
Add website security scanner (backend + frontend)

### DIFF
--- a/backend/app/db_models.py
+++ b/backend/app/db_models.py
@@ -277,3 +277,63 @@ class SandboxArtifact(Base):
     storage_path: Mapped[str] = mapped_column(String(512), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
+
+class SecurityScanStatus(str, enum.Enum):
+    queued = "queued"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+
+
+class SecurityIssueSeverity(str, enum.Enum):
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+
+
+class SecurityScanRun(Base):
+    __tablename__ = "security_scan_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[SecurityScanStatus] = mapped_column(Enum(SecurityScanStatus), default=SecurityScanStatus.queued, nullable=False)
+
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    score: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    issues: Mapped[list["SecurityScanIssue"]] = relationship("SecurityScanIssue", back_populates="run", cascade="all,delete-orphan")
+    artifacts: Mapped[list["SecurityScanArtifact"]] = relationship("SecurityScanArtifact", back_populates="run", cascade="all,delete-orphan")
+
+
+class SecurityScanIssue(Base):
+    __tablename__ = "security_scan_issues"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("security_scan_runs.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    severity: Mapped[SecurityIssueSeverity] = mapped_column(Enum(SecurityIssueSeverity), nullable=False)
+    category: Mapped[str] = mapped_column(String(64), nullable=False) 
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    remediation: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    
+    run: Mapped["SecurityScanRun"] = relationship("SecurityScanRun", back_populates="issues")
+
+
+class SecurityScanArtifact(Base):
+    __tablename__ = "security_scan_artifacts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("security_scan_runs.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    artifact_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    storage_path: Mapped[str] = mapped_column(String(512), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    
+    run: Mapped["SecurityScanRun"] = relationship("SecurityScanRun", back_populates="artifacts")
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from .routers_api_keys import router as api_keys_router
 from .routers_scans import router as scans_router
 from .routers_intel import router as intel_router
 from .routers_sandbox import router as sandbox_router
+from .routers_security_scans import router as security_scans_router
 from .sandbox.queue import enqueue_sandbox_run
 
 API_PORT = int(os.environ.get("API_PORT", "8000"))
@@ -52,6 +53,7 @@ app.include_router(api_keys_router)
 app.include_router(scans_router)
 app.include_router(intel_router)
 app.include_router(sandbox_router)
+app.include_router(security_scans_router)
 
 
 @app.get("/api/health", response_model=HealthResponse)

--- a/backend/app/routers_security_scans.py
+++ b/backend/app/routers_security_scans.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .db import get_db
+from .db_models import SecurityScanRun, SecurityScanStatus, UserRole
+from .dependencies import CurrentTenant, require_role
+from .security_scanner.queue import enqueue_security_scan
+from .schemas_saas import SecurityScanCreateRequest, SecurityScanResponse
+
+
+router = APIRouter(prefix="/security-scans", tags=["security-scans"])
+
+
+@router.post("", response_model=SecurityScanResponse, dependencies=[Depends(require_role(UserRole.analyst))])
+def create_security_scan(
+    payload: SecurityScanCreateRequest,
+    tenant: CurrentTenant,
+    db: Session = Depends(get_db),
+):
+    run = SecurityScanRun(
+        tenant_id=tenant.id,
+        url=payload.url,
+        status=SecurityScanStatus.queued,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    enqueue_security_scan(run.id)
+
+    return run
+
+
+@router.get("", response_model=List[SecurityScanResponse])
+def list_security_scans(tenant: CurrentTenant, db: Session = Depends(get_db)):
+    runs = (
+        db.query(SecurityScanRun)
+        .filter(SecurityScanRun.tenant_id == tenant.id)
+        .order_by(SecurityScanRun.id.desc())
+        .limit(100)
+        .all()
+    )
+    return runs
+
+
+@router.get("/{scan_id}", response_model=SecurityScanResponse)
+def get_security_scan(scan_id: int, tenant: CurrentTenant, db: Session = Depends(get_db)):
+    run = (
+        db.query(SecurityScanRun)
+        .filter(SecurityScanRun.id == scan_id, SecurityScanRun.tenant_id == tenant.id)
+        .first()
+    )
+    if not run:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Security scan not found")
+    return run

--- a/backend/app/schemas_saas.py
+++ b/backend/app/schemas_saas.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, EmailStr, Field
 
-from .db_models import UserRole, TenantStatus, AlertStatus, SandboxStatus
+from .db_models import UserRole, TenantStatus, AlertStatus, SandboxStatus, SecurityScanStatus, SecurityIssueSeverity
 
 
 class TokenResponse(BaseModel):
@@ -176,6 +176,50 @@ class SandboxEventResponse(BaseModel):
     event_type: str
     timestamp: datetime
     data: Dict[str, Any]
+
+    class Config:
+        from_attributes = True
+
+
+class SecurityScanCreateRequest(BaseModel):
+    url: str
+
+
+class SecurityScanIssueResponse(BaseModel):
+    id: int
+    run_id: int
+    severity: SecurityIssueSeverity
+    category: str
+    description: str
+    remediation: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
+class SecurityScanArtifactResponse(BaseModel):
+    id: int
+    run_id: int
+    artifact_type: str
+    storage_path: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class SecurityScanResponse(BaseModel):
+    id: int
+    tenant_id: int
+    url: str
+    status: SecurityScanStatus
+    started_at: Optional[datetime]
+    finished_at: Optional[datetime]
+    score: Optional[int]
+    summary: Optional[str]
+    
+    issues: List[SecurityScanIssueResponse] = Field(default_factory=list)
+    artifacts: List[SecurityScanArtifactResponse] = Field(default_factory=list)
 
     class Config:
         from_attributes = True

--- a/backend/app/security_scanner/queue.py
+++ b/backend/app/security_scanner/queue.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover
+    redis = None
+
+
+REDIS_URL = os.getenv("REDIS_URL")
+QUEUE_NAME = os.getenv("SECURITY_SCAN_QUEUE_NAME", "security_scan_queue")
+
+_client = redis.from_url(REDIS_URL) if redis and REDIS_URL else None
+
+
+def enqueue_security_scan(run_id: int) -> None:
+    """
+    Enqueue a security scan run ID for processing.
+    """
+    if _client is None:
+        return
+    _client.lpush(QUEUE_NAME, str(run_id))
+
+
+def dequeue_security_scan(block: bool = True, timeout: int = 5) -> Optional[int]:
+    """
+    Dequeue a security scan run ID from the queue.
+    """
+    if _client is None:
+        return None
+    if block:
+        item = _client.brpop(QUEUE_NAME, timeout=timeout)
+    else:
+        item = _client.rpop(QUEUE_NAME)
+    if not item:
+        return None
+    value = item[1] if isinstance(item, (list, tuple)) else item
+    try:
+        return int(value)
+    except Exception:
+        return None

--- a/backend/app/security_scanner/worker.py
+++ b/backend/app/security_scanner/worker.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Tuple, Set
+
+from sqlalchemy.orm import Session
+from bs4 import BeautifulSoup
+
+from ..db_models import (
+    SecurityScanRun,
+    SecurityScanIssue,
+    SecurityScanArtifact,
+    SecurityScanStatus,
+    SecurityIssueSeverity,
+    ScanResult
+)
+from ..services.domain_intel import evaluate_domain_for_url
+from ..schemas import ExplanationReason
+
+try:
+    from playwright.async_api import async_playwright  # type: ignore
+except Exception:  # pragma: no cover
+    async_playwright = None
+
+SECURITY_SCAN_TIMEOUT_SECONDS = int(os.getenv("SECURITY_SCAN_TIMEOUT_SECONDS", "30"))
+SECURITY_SCAN_STORAGE_ROOT = os.getenv("SECURITY_SCAN_STORAGE_ROOT", "security_artifacts")
+
+
+@dataclass
+class ScanSignals:
+    suspicious_js_execution: bool = False
+    external_credential_endpoints: Set[str] = None
+    suspicious_domains: Set[str] = None
+    ip_based_hosts: Set[str] = None
+    missing_csp: bool = False
+    missing_hsts: bool = False
+    missing_x_frame_options: bool = False
+    missing_referrer_policy: bool = False
+    http_downgrade: bool = False
+    excessive_redirects: bool = False
+
+    def __post_init__(self):
+        self.external_credential_endpoints = set()
+        self.suspicious_domains = set()
+        self.ip_based_hosts = set()
+
+
+async def _run_playwright(db: Session, run: SecurityScanRun, storage_dir: Path) -> Tuple[List[SecurityScanIssue], List[SecurityScanArtifact], ScanSignals]:
+    if async_playwright is None:
+        return [], [], ScanSignals()
+
+    issues: List[SecurityScanIssue] = []
+    artifacts: List[SecurityScanArtifact] = []
+    signals = ScanSignals()
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
+        )
+        context = await browser.new_context()
+        page = await context.new_page()
+
+        js_hook = """
+        (() => {
+          const log = (...args) => console.log("__SCAN_JS_EVENT__", ...args);
+          const origEval = window.eval;
+          window.eval = function(...args) { log("eval"); return origEval.apply(this, args); };
+          const origAtob = window.atob;
+          window.atob = function(...args) { log("atob"); return origAtob.apply(this, args); };
+        })();
+        """
+        await context.add_init_script(js_hook)
+
+        # 1. Network Request Analysis
+        def handle_request(request):
+            url = request.url
+            if re.match(r'^https?://[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+', url):
+                signals.ip_based_hosts.add(url)
+
+            if request.method in ["POST", "PUT"] and ("login" in url.lower() or "auth" in url.lower() or "submit" in url.lower()):
+                # Exclude internal 
+                pass # Check in details later based on base url
+
+        page.on("request", handle_request)
+
+        # 2. Security Headers
+        async def handle_response(response):
+            if response.url == run.url:
+                headers = response.headers
+                
+                # Check for redirects
+                if response.status in [301, 302, 307, 308]:
+                    location = headers.get("location", "")
+                    if run.url.startswith("https") and location.startswith("http://"):
+                        signals.http_downgrade = True
+
+                # Check security headers on the final response
+                if response.status == 200:
+                    x_frame_options = headers.get("x-frame-options", "").upper()
+                    if x_frame_options not in ["DENY", "SAMEORIGIN"]:
+                        signals.missing_x_frame_options = True
+                    
+                    if "strict-transport-security" not in headers:
+                        signals.missing_hsts = True
+                    
+                    if "content-security-policy" not in headers:
+                        signals.missing_csp = True
+                    
+                    if "referrer-policy" not in headers:
+                        signals.missing_referrer_policy = True
+
+        page.on("response", lambda resp: asyncio.ensure_future(handle_response(resp)))
+
+        async def handle_console(msg):
+            if msg.text().startswith("__SCAN_JS_EVENT__"):
+                signals.suspicious_js_execution = True
+
+        page.on("console", lambda msg: asyncio.ensure_future(handle_console(msg)))
+
+        try:
+            response = await page.goto(run.url, wait_until="networkidle", timeout=SECURITY_SCAN_TIMEOUT_SECONDS * 1000)
+            
+            # Check redirect chain length
+            chain = response.request.redirect_chain if response else []
+            if len(chain) > 3:
+                signals.excessive_redirects = True
+
+            # External Credential endpoint check.
+            forms = await page.locator("form").all()
+            base_domain = run.url.split("/")[2] if "//" in run.url else run.url.split("/")[0]
+
+            for form in forms:
+                action = await form.get_attribute("action")
+                has_password = await form.locator('input[type="password"]').count() > 0
+                if action and has_password:
+                    action_domain = action.split("/")[2] if "//" in action else ""
+                    if action_domain and action_domain != base_domain:
+                         signals.external_credential_endpoints.add(action)
+
+        except Exception as e:
+            pass
+
+        # Capture final screenshot
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        screenshot_path = storage_dir / "final.png"
+        try:
+            await page.screenshot(path=str(screenshot_path), full_page=True)
+            artifacts.append(
+                SecurityScanArtifact(
+                    run_id=run.id,
+                    artifact_type="screenshot",
+                    storage_path=str(screenshot_path),
+                    created_at=datetime.utcnow()
+                )
+            )
+        except Exception:
+            pass
+        
+        # DOM Analysis
+        try:
+            html = await page.content()
+            soup = BeautifulSoup(html, "html.parser")
+            
+            # Check for hidden credential inputs
+            hidden_creds = soup.find_all("input", type="hidden", attrs={"name": re.compile(r'user|pass|auth|login', re.I)})
+            if hidden_creds:
+                 issues.append(SecurityScanIssue(
+                     run_id=run.id,
+                     severity=SecurityIssueSeverity.HIGH,
+                     category="Forms",
+                     description="Found hidden credential inputs in the DOM.",
+                     remediation="Remove hidden inputs used for authentication as they can expose sensitive data or be manipulated."
+                 ))
+
+        except Exception:
+            pass
+
+        await browser.close()
+
+    # Generate Issues from signals
+    if signals.suspicious_js_execution:
+        issues.append(SecurityScanIssue(
+            run_id=run.id,
+            severity=SecurityIssueSeverity.HIGH,
+            category="Scripts",
+            description="Suspicious JavaScript execution detected (e.g., eval or atob parsing dynamically).",
+            remediation="Refactor code to avoid dynamic evaluation of scripts and ensure scripts are served from trusted locations."
+        ))
+
+    if signals.external_credential_endpoints:
+        issues.append(SecurityScanIssue(
+            run_id=run.id,
+            severity=SecurityIssueSeverity.CRITICAL,
+            category="Forms",
+            description=f"Form posting credentials to external domain: {', '.join(signals.external_credential_endpoints)}",
+            remediation="Ensure credential submission endpoints match the origin domain to prevent data exfiltration."
+        ))
+
+    if signals.ip_based_hosts:
+        issues.append(SecurityScanIssue(
+            run_id=run.id,
+            severity=SecurityIssueSeverity.MEDIUM,
+            category="Network",
+            description=f"Found resources requested from raw IP addresses: {', '.join(signals.ip_based_hosts)}",
+            remediation="Use domain names instead of raw IP addresses for reliable routing and HTTPS validation."
+        ))
+
+    if signals.missing_csp:
+        issues.append(SecurityScanIssue(
+            run_id=run.id, severity=SecurityIssueSeverity.HIGH, category="Headers",
+            description="Missing Content-Security-Policy header.", remediation="Implement a strict CSP to restrict script and resource loading."
+        ))
+    if signals.missing_hsts:
+        issues.append(SecurityScanIssue(
+            run_id=run.id, severity=SecurityIssueSeverity.MEDIUM, category="Headers",
+            description="Missing Strict-Transport-Security header.", remediation="Enable HSTS to enforce secure connections."
+        ))
+    if signals.missing_x_frame_options:
+        issues.append(SecurityScanIssue(
+            run_id=run.id, severity=SecurityIssueSeverity.MEDIUM, category="Headers",
+            description="Missing or weak X-Frame-Options header.", remediation="Set X-Frame-Options to DENY or SAMEORIGIN to prevent clickjacking."
+        ))
+    
+    if signals.http_downgrade:
+        issues.append(SecurityScanIssue(
+            run_id=run.id, severity=SecurityIssueSeverity.CRITICAL, category="TLS",
+            description="HTTP downgrade redirect detected.", remediation="Ensure all redirects maintain or upgrade to HTTPS."
+        ))
+
+    if signals.excessive_redirects:
+        issues.append(SecurityScanIssue(
+            run_id=run.id, severity=SecurityIssueSeverity.LOW, category="Redirects",
+            description="Excessive redirect chains.", remediation="Minimize redirects to reduce attack surface and improve performance."
+        ))
+
+    return issues, artifacts, signals
+
+
+async def execute_security_scan(db: Session, run: SecurityScanRun) -> None:
+    run.status = SecurityScanStatus.running
+    run.started_at = datetime.utcnow()
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    storage_dir = Path(SECURITY_SCAN_STORAGE_ROOT) / str(run.id)
+
+    try:
+        issues, artifacts, signals = await _run_playwright(db, run, storage_dir)
+
+        # Domain intel & model explanation signals
+        try:
+            _domain, domain_risk, _reasons = evaluate_domain_for_url(db, run.url)
+            if domain_risk > 0.5:
+                issues.append(SecurityScanIssue(
+                    run_id=run.id, severity=SecurityIssueSeverity.HIGH, category="Network",
+                    description=f"High domain risk score: {domain_risk}",
+                    remediation="Investigate root cause of domain blacklisting or suspicious registrar configurations."
+                ))
+        except Exception:
+            pass
+
+        # Calculate score (start from 100, deduct based on severity)
+        score = 100
+        for issue in issues:
+            if issue.severity == SecurityIssueSeverity.CRITICAL:
+                score -= 20
+            elif issue.severity == SecurityIssueSeverity.HIGH:
+                score -= 15
+            elif issue.severity == SecurityIssueSeverity.MEDIUM:
+                score -= 10
+            elif issue.severity == SecurityIssueSeverity.LOW:
+                score -= 5
+        
+        run.score = max(0, min(100, score))
+        run.summary = f"Scan complete. Found {len(issues)} issues."
+        run.finished_at = datetime.utcnow()
+        run.status = SecurityScanStatus.completed
+
+        for issue in issues:
+            db.add(issue)
+        for art in artifacts:
+            db.add(art)
+
+        db.add(run)
+        db.commit()
+
+    except Exception as e:
+        run.status = SecurityScanStatus.failed
+        run.finished_at = datetime.utcnow()
+        run.summary = f"Security Scan failed: {e}"
+        db.add(run)
+        db.commit()

--- a/cli/scanphish.py
+++ b/cli/scanphish.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from urllib import request as urlrequest
@@ -38,9 +39,25 @@ class ScanResult:
     explanation: Dict[str, Any]
 
 
+@dataclass
+class SecurityScanResult:
+    url: str
+    status: str
+    score: Optional[int]
+    summary: Optional[str]
+    issues: List[Dict[str, Any]]
+
+
 def _post_json(url: str, payload: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
     data = json.dumps(payload).encode("utf-8")
     req = urlrequest.Request(url, data=data, headers={"Content-Type": "application/json", **(headers or {})})
+    with urlrequest.urlopen(req, timeout=20) as resp:
+        body = resp.read()
+    return json.loads(body.decode("utf-8"))
+
+
+def _get_json(url: str, headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    req = urlrequest.Request(url, headers=headers or {})
     with urlrequest.urlopen(req, timeout=20) as resp:
         body = resp.read()
     return json.loads(body.decode("utf-8"))
@@ -65,6 +82,43 @@ def run_scan(api_base: str, target_url: str, api_key: Optional[str] = None) -> S
         prediction=resp.get("prediction", "unknown"),
         confidence=float(resp.get("confidence", 0.0)),
         explanation=resp.get("explanation") or {},
+    )
+
+
+def run_security_scan(api_base: str, target_url: str, api_key: Optional[str] = None) -> SecurityScanResult:
+    endpoint = api_base.rstrip("/") + "/security-scans"
+    headers: Dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        # 1. Enqueue
+        resp = _post_json(endpoint, {"url": target_url}, headers=headers)
+        scan_id = resp["id"]
+        print(f"[*] Security scan queued with ID: {scan_id}")
+
+        # 2. Poll
+        poll_endpoint = f"{endpoint}/{scan_id}"
+        while True:
+            resp = _get_json(poll_endpoint, headers=headers)
+            status = resp.get("status")
+            if status in ("completed", "failed"):
+                break
+            time.sleep(2)
+            print(".", end="", flush=True)
+        print()
+    except HTTPError as e:
+        msg = e.read().decode("utf-8", errors="ignore")
+        raise SystemExit(f"[scanphish security] API error {e.code}: {msg}")
+    except URLError as e:
+        raise SystemExit(f"[scanphish security] Failed to reach API at {endpoint}: {e.reason}")
+
+    return SecurityScanResult(
+        url=target_url,
+        status=resp.get("status", "unknown"),
+        score=resp.get("score"),
+        summary=resp.get("summary"),
+        issues=resp.get("issues", [])
     )
 
 
@@ -97,6 +151,30 @@ def print_human_readable(result: ScanResult) -> None:
             print(f"  [{category}/{code} | weight={weight:.2f}] {message}")
 
 
+def print_security_readable(result: SecurityScanResult) -> None:
+    print("--- Website Security Scanner ---")
+    print(f"URL          : {result.url}")
+    print(f"Status       : {result.status.upper()}")
+    
+    if result.status == "failed":
+        print(f"Summary      : {result.summary}")
+        return
+
+    print(f"Score        : {result.score}/100")
+    print(f"Summary      : {result.summary}")
+
+    if result.issues:
+        print("\nIdentified Issues:")
+        for item in result.issues:
+            sev = item.get("severity", "UNKNOWN")
+            cat = item.get("category", "unknown")
+            desc = item.get("description", "")
+            rem = item.get("remediation", "")
+            print(f"  [{sev}] {cat}: {desc}")
+            if rem:
+                print(f"    -> Remediation: {rem}")
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Scan a URL for phishing risk using the backend detection API.")
     parser.add_argument("url", help="URL to scan, e.g. https://example.com")
@@ -111,6 +189,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="Optional API key or bearer token to include as Authorization header.",
     )
     parser.add_argument(
+        "--security",
+        action="store_true",
+        help="Run an async Website Security Scan using Playwright instead of a prediction scan.",
+    )
+    parser.add_argument(
         "--fail-on",
         choices=["phishing", "suspicious", "never"],
         default="phishing",
@@ -122,17 +205,24 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     args = parser.parse_args(argv)
 
-    result = run_scan(api_base=args.api_base, target_url=args.url, api_key=args.api_key)
-    print_human_readable(result)
-
-    if args.fail_on == "never":
+    if args.security:
+        result = run_security_scan(api_base=args.api_base, target_url=args.url, api_key=args.api_key)
+        print_security_readable(result)
+        if result.status == "failed" or (result.score is not None and result.score < 80 and args.fail_on != "never"):
+            return 1
         return 0
+    else:
+        result = run_scan(api_base=args.api_base, target_url=args.url, api_key=args.api_key)
+        print_human_readable(result)
 
-    if result.prediction == "phishing":
-        return 1
-    if result.prediction == "suspicious" and args.fail_on == "suspicious":
-        return 1
-    return 0
+        if args.fail_on == "never":
+            return 0
+
+        if result.prediction == "phishing":
+            return 1
+        if result.prediction == "suspicious" and args.fail_on == "suspicious":
+            return 1
+        return 0
 
 
 if __name__ == "__main__":

--- a/frontend/src/api/scanner.ts
+++ b/frontend/src/api/scanner.ts
@@ -1,0 +1,46 @@
+import apiClient from './client';
+
+export interface SecurityScanIssue {
+  id: number;
+  run_id: number;
+  severity: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW';
+  category: string;
+  description: string;
+  remediation: string | null;
+}
+
+export interface SecurityScanArtifact {
+  id: number;
+  run_id: number;
+  artifact_type: string;
+  storage_path: string;
+  created_at: string;
+}
+
+export interface SecurityScanResponse {
+  id: number;
+  tenant_id: number;
+  url: string;
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  started_at: string | null;
+  finished_at: string | null;
+  score: number | null;
+  summary: string | null;
+  issues: SecurityScanIssue[];
+  artifacts: SecurityScanArtifact[];
+}
+
+export const scannerApi = {
+  createScan: async (url: string): Promise<SecurityScanResponse> => {
+    const response = await apiClient.post('/security-scans', { url });
+    return response.data;
+  },
+  getScans: async (): Promise<SecurityScanResponse[]> => {
+    const response = await apiClient.get('/security-scans');
+    return response.data;
+  },
+  getScanById: async (id: number | string): Promise<SecurityScanResponse> => {
+    const response = await apiClient.get(`/security-scans/${id}`);
+    return response.data;
+  }
+};

--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -11,6 +11,7 @@ export const DashboardLayout = () => {
     { label: 'Dashboard', path: '/', icon: LayoutDashboard },
     { label: 'Scans', path: '/scans', icon: Search },
     { label: 'Sandbox', path: '/sandbox', icon: Box },
+    { label: 'Security Scanner', path: '/security-scanner', icon: ShieldAlert },
     { label: 'Threat Intel', path: '/intel', icon: ShieldAlert },
     { label: 'Admin', path: '/admin', icon: Settings },
   ];

--- a/frontend/src/pages/SecurityScanner/SecurityScannerPage.tsx
+++ b/frontend/src/pages/SecurityScanner/SecurityScannerPage.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { scannerApi, SecurityScanResponse } from '../../api/scanner';
+import { ShieldCheck, AlertTriangle, AlertCircle, Info, Loader2, ArrowRight } from 'lucide-react';
+
+const SeverityIcon = ({ severity }: { severity: string }) => {
+  switch (severity) {
+    case 'CRITICAL': return <AlertTriangle className="text-error w-5 h-5" />;
+    case 'HIGH': return <AlertCircle className="text-warning w-5 h-5" />;
+    case 'MEDIUM': return <AlertCircle className="text-orange-400 w-5 h-5" />;
+    case 'LOW': return <Info className="text-info w-5 h-5" />;
+    default: return <Info className="w-5 h-5" />;
+  }
+};
+
+export const SecurityScannerPage = () => {
+  const [url, setUrl] = useState('');
+  const [activeScanId, setActiveScanId] = useState<number | null>(null);
+  const queryClient = useQueryClient();
+
+  const { data: scans, isLoading: scansLoading } = useQuery({
+    queryKey: ['security_scans'],
+    queryFn: () => scannerApi.getScans(),
+    refetchInterval: 5000,
+  });
+
+  const { data: activeScan, isLoading: activeScanLoading } = useQuery({
+    queryKey: ['security_scan', activeScanId],
+    queryFn: () => activeScanId ? scannerApi.getScanById(activeScanId) : null,
+    enabled: !!activeScanId,
+    refetchInterval: (data: any) => data?.status === 'queued' || data?.status === 'running' ? 2000 : false,
+  });
+
+  const createScanMutation = useMutation({
+    mutationFn: (targetUrl: string) => scannerApi.createScan(targetUrl),
+    onSuccess: (data) => {
+      setActiveScanId(data.id);
+      queryClient.invalidateQueries({ queryKey: ['security_scans'] });
+      setUrl('');
+    }
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (url) {
+       createScanMutation.mutate(url);
+    }
+  };
+
+  const getScoreColor = (score: number | null) => {
+    if (score === null) return 'text-base-content';
+    if (score >= 80) return 'text-success';
+    if (score >= 50) return 'text-warning';
+    return 'text-error';
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <ShieldCheck className="w-8 h-8 text-primary" />
+            Website Security Scanner
+          </h1>
+          <p className="text-base-content/70 mt-1">Deep analysis of web application security configurations and dynamic behaviors.</p>
+        </div>
+      </div>
+
+      <div className="card bg-base-100 shadow-sm border border-base-300">
+        <div className="card-body">
+          <form onSubmit={handleSubmit} className="flex gap-4">
+            <input
+              type="url"
+              placeholder="https://example.com"
+              className="input input-bordered flex-1"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              required
+            />
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={createScanMutation.isPending}
+            >
+              {createScanMutation.isPending ? <Loader2 className="w-5 h-5 animate-spin" /> : 'Start Scan'}
+            </button>
+          </form>
+        </div>
+      </div>
+
+      {activeScan && (
+        <div className="card bg-base-100 shadow-sm border border-base-300">
+          <div className="card-body">
+            <h2 className="card-title flex items-center gap-2">
+              Scan Results: {activeScan.url}
+              {['queued', 'running'].includes(activeScan.status) && <Loader2 className="w-4 h-4 animate-spin text-primary" />}
+            </h2>
+            
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-4">
+              <div className="col-span-1">
+                <div className="stat bg-base-200 rounded-box">
+                  <div className="stat-title">Security Score</div>
+                  <div className={`stat-value ${getScoreColor(activeScan.score)}`}>
+                    {activeScan.score !== null ? activeScan.score : '--'}
+                  </div>
+                  <div className="stat-desc">Out of 100 points</div>
+                </div>
+                
+                <div className="mt-4">
+                  <h3 className="font-semibold mb-2">Status</h3>
+                  <div className={`badge ${
+                    activeScan.status === 'completed' ? 'badge-success' :
+                    activeScan.status === 'failed' ? 'badge-error' : 'badge-primary'
+                  }`}>
+                    {activeScan.status.toUpperCase()}
+                  </div>
+                  {activeScan.summary && <p className="text-sm mt-2 text-base-content/70">{activeScan.summary}</p>}
+                </div>
+
+                {activeScan.artifacts?.length > 0 && (
+                  <div className="mt-6">
+                    <h3 className="font-semibold mb-2">Artifacts</h3>
+                    {activeScan.artifacts.map(a => (
+                      <div key={a.id} className="text-sm">
+                         📸 {a.artifact_type}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              
+              <div className="col-span-2 space-y-4">
+                <h3 className="font-semibold border-b border-base-200 pb-2">Identified Issues</h3>
+                {activeScan.issues?.length === 0 && activeScan.status === 'completed' ? (
+                   <p className="text-success flex items-center gap-2">
+                     <ShieldCheck className="w-5 h-5" /> No critical security issues found.
+                   </p>
+                ) : (
+                  <div className="space-y-3 max-h-[400px] overflow-y-auto pr-2">
+                    {activeScan.issues?.map(issue => (
+                      <div key={issue.id} className="bg-base-200 p-4 rounded-lg flex gap-4 items-start">
+                        <div className="pt-1"><SeverityIcon severity={issue.severity} /></div>
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <span className={`badge badge-sm ${
+                              issue.severity === 'CRITICAL' ? 'badge-error' :
+                              issue.severity === 'HIGH' ? 'bg-warning text-warning-content border-warning' :
+                              issue.severity === 'MEDIUM' ? 'bg-orange-400 text-white border-orange-400' : 'badge-info'
+                            }`}>{issue.severity}</span>
+                            <span className="text-xs font-bold uppercase tracking-wider text-base-content/60">{issue.category}</span>
+                          </div>
+                          <p className="mt-2 font-medium">{issue.description}</p>
+                          {issue.remediation && (
+                            <div className="mt-3 text-sm bg-base-100 p-3 rounded border border-base-300 flex items-start gap-2">
+                              <ArrowRight className="w-4 h-4 mt-0.5 opacity-50 flex-shrink-0" />
+                              <span className="opacity-80 break-words">{issue.remediation}</span>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="card bg-base-100 shadow-sm border border-base-300">
+        <div className="card-body">
+          <h2 className="card-title mb-4">Recent Scans</h2>
+          {scansLoading ? (
+            <div className="flex justify-center p-8"><Loader2 className="w-8 h-8 animate-spin text-primary" /></div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>URL</th>
+                    <th>Score</th>
+                    <th>Status</th>
+                    <th>Date</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {scans?.map(scan => (
+                    <tr key={scan.id} className="hover">
+                      <td>#{scan.id}</td>
+                      <td className="max-w-[300px] truncate" title={scan.url}>{scan.url}</td>
+                      <td>
+                        <span className={`font-semibold ${getScoreColor(scan.score)}`}>
+                          {scan.score !== null ? scan.score : '-'}
+                        </span>
+                      </td>
+                      <td>
+                        <div className={`badge badge-sm ${
+                          scan.status === 'completed' ? 'badge-success' :
+                          scan.status === 'failed' ? 'badge-error' : 'badge-primary'
+                        }`}>
+                          {scan.status}
+                        </div>
+                      </td>
+                      <td>{new Date(scan.started_at || scan.finished_at || '').toLocaleString()}</td>
+                      <td>
+                        <button 
+                          className="btn btn-sm btn-ghost"
+                          onClick={() => setActiveScanId(scan.id)}
+                        >
+                          View Details
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {scans?.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="text-center py-4 text-base-content/50">No recent security scans</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -9,6 +9,7 @@ import { ScanDetailsPage } from './pages/Scans/ScanDetailsPage';
 import { SandboxPage } from './pages/Sandbox/SandboxPage';
 import { ThreatIntelPage } from './pages/ThreatIntel/ThreatIntelPage';
 import { TenantAdminPage } from './pages/Admin/TenantAdminPage';
+import { SecurityScannerPage } from './pages/SecurityScanner/SecurityScannerPage';
 
 export const MainRouter = () => {
   const { isAuthenticated } = useAuth();
@@ -23,6 +24,7 @@ export const MainRouter = () => {
         <Route path="/scans/:id" element={<ScanDetailsPage />} />
         <Route path="/sandbox" element={<SandboxPage />} />
         <Route path="/sandbox/:id" element={<SandboxPage />} />
+        <Route path="/security-scanner" element={<SecurityScannerPage />} />
         <Route path="/intel" element={<ThreatIntelPage />} />
         <Route path="/admin" element={<TenantAdminPage />} />
       </Route>


### PR DESCRIPTION
Introduce a Website Security Scanner feature across backend, CLI, and frontend.

Backend: add DB models and enums (SecurityScanRun, SecurityScanIssue, SecurityScanArtifact, SecurityScanStatus, SecurityIssueSeverity); new /security-scans router to create/list/get runs; Redis queue helper to enqueue/dequeue run IDs; an async worker using Playwright to perform dynamic scans, DOM/network/header analysis, produce artifacts (screenshots), generate issues, compute a score, and persist results.

CLI: add --security option and commands to enqueue a security scan, poll for completion, and pretty-print results.

Frontend: add API client for scanner endpoints, a Security Scanner page and route, and a dashboard menu item; UI supports creating scans, polling status, viewing score, artifacts, and detailed issues.

Notes: storage root, timeouts, and queue name are configurable via environment variables; scoring is heuristic (deductions per severity).